### PR TITLE
Add dark mode

### DIFF
--- a/popup/choose_bootstrap_version.css
+++ b/popup/choose_bootstrap_version.css
@@ -1,4 +1,5 @@
 html, body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   width: max-content;
 }
 
@@ -10,4 +11,16 @@ html, body {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+label span {
+  opacity: 0.75;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color-scheme: dark;
+    background-color: #212529;
+    color: #fff;
+  }
 }

--- a/popup/choose_bootstrap_version.html
+++ b/popup/choose_bootstrap_version.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="choose_bootstrap_version.css" />
+    <title>Choose Bootstrap Version</title>
   </head>
   <body>
     <div id="popup-content">
@@ -16,7 +17,7 @@
       </div>
       <div>
         <input type="checkbox" id="bs5" name="bs5" />
-        <label for="bs5">Bootstrap 5<br>(removed in Bootstrap 6)</label>
+        <label for="bs5">Bootstrap 5<br><span>(removed in Bootstrap 6)</span></label>
       </div>
       <button type="reset">Reset</button>
     </div>


### PR DESCRIPTION
- For users with dark mode on it's a bit nicer to have a dark mode panel.
- I set the dark background to same hex value as Bootstrap 5 dark mode
- Opinionated change- set the Bootstrap 6 comment to be slightly transparent to de-emphasize it a bit
- I added HTML title and lang to make HTML linters happy (and potentially helpful for screen readers?)
- Set the font to use system fonts as Bootstrap does (not sure what it defaults to otherwise to be honest)

Feel free to edit and remove any part of this PR as you wish :-) 

Edge (Windows 11) screenshot:
![image](https://github.com/user-attachments/assets/f3192209-801e-463a-b8e1-1d136c07c20c)
